### PR TITLE
Copy wasm renderer modules to asset directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # production
 /build
+/public/typst-renderer.wasm
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
+    "prepare-assets": "node ./scripts/copy-assets.js",
     "start": "set PORT=3100 && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",

--- a/script/copy-asset.js
+++ b/script/copy-asset.js
@@ -1,0 +1,4 @@
+
+const { copyFileSync } = require('fs');
+
+copyFileSync('node_modules/@myriaddreamin/typst-ts-renderer/pkg/typst_ts_renderer_bg.wasm', 'public/typst-renderer.wasm');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,14 +17,15 @@ TypstDocument.setWasmModuleInitOptions({
     // }),
   ],
   getModule: () =>
-    '/node_modules/@myriaddreamin/typst-ts-renderer/pkg/typst_ts_renderer_bg.wasm',
+    '/typst-renderer.wasm',
 });
 
 export const App = () => {
   const [artifact, setArtifact] = useState<Uint8Array>(new Uint8Array(0));
 
   const getArtifactData = async () => {
-    const response = await fetch('http://localhost:8081/main.artifact.json');
+    // please get artifact 
+    const response = await fetch('http://localhost:20810/corpus/skyzh-cv/main.white.artifact.sir.in');
     const buffer = await response.arrayBuffer();
     const artifactData = new Uint8Array(buffer);
   

--- a/src/index.html
+++ b/src/index.html
@@ -16,7 +16,7 @@
     />
     <script>
       pdfjsLib.GlobalWorkerOptions.workerSrc =
-        'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.5.141/pdf.worker.min.js';
+        "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.5.141/pdf.worker.min.js";
     </script>
     <style>
       body {


### PR DESCRIPTION
The react dev server is redirecting request from `/node_modules/xxx/typst_ts_renderer_bg.wasm` to `/index.html`.
Copy needed wasm renderer module to asset directory by running `npm run prepare-assets`, So that the evil react don't handle it.